### PR TITLE
Add @context = http://schema.org and use archive name

### DIFF
--- a/includes/breadcrumbs.php
+++ b/includes/breadcrumbs.php
@@ -295,7 +295,7 @@ if ( ! class_exists( 'Breadcrumbs' ) ) :
 				$post_type = get_post_type_object( get_post_type( $post ) );
 
 				if ( ! empty( $post_type->has_archive ) ) {
-					$this->add_item( $post_type->labels->singular_name, get_post_type_archive_link( get_post_type( $post ) ) );
+					$this->add_item( $post_type->labels->name, get_post_type_archive_link( get_post_type( $post ) ) );
 				}
 			} else {
 				$cat = current( get_the_category( $post ) );
@@ -463,6 +463,7 @@ if ( ! class_exists( 'Breadcrumbs' ) ) :
 			}
 
 			$markup                    = array();
+			$markup['@context']        = 'http://schema.org';
 			$markup['@type']           = 'BreadcrumbList';
 			$markup['itemListElement'] = array();
 


### PR DESCRIPTION
As discussed in https://wordpress.org/support/topic/suggestion-dont-show-current-page-title/ I wrote a small pull request for my two suggestions. 

I am using `$post_type->labels->name` instead of `$post_type->labels->singular_name` for the a post type archive and added `@context' = http://schema.org` for the JSON-LD schema.