### PR TITLE
Bug fixes...

### DIFF
--- a/includes/breadcrumbs.php
+++ b/includes/breadcrumbs.php
@@ -274,6 +274,14 @@ if ( ! class_exists( Breadcrumbs::class ) ) :
 				);
 			}
 
+			// Ensure shortcode brackets ae HTML entity encoded, so shortcodes are not ran if they exist in breadcrumb name.
+			$replace = array(
+				'[' => '&#91;',
+				']' => '&#93;',
+			);
+
+			$breadcrumb = str_replace( array_keys( $replace ), array_values( $replace ), $breadcrumb );
+
 			// Allow third-party to filter the breadcrumb trail HTML.
 			$breadcrumb = apply_filters( 'breadcrumb_block_get_breadcrumb_trail', $breadcrumb, $args, $this );
 


### PR DESCRIPTION
Pull contains to fixes:

1. If shortcodes exist in the post title, the shortcodes were expanded by WordPress. This entity encodes bracks to esure WP does not expand them.
2. If the post type was hierarchal and had parents, the post parents were not used for the breadcrumb. This ensure post parent are used if they exist and falls back to the post archive if it has one.